### PR TITLE
Fixes for 5a run schemes and 5a test files

### DIFF
--- a/a5-diff/test1/fileT1A.txt
+++ b/a5-diff/test1/fileT1A.txt
@@ -1,2 +1,3 @@
 Hi, this is a testfile.
 Testfile 1 to be precise.
+

--- a/a5-diff/test4/expectedResult4.txt
+++ b/a5-diff/test4/expectedResult4.txt
@@ -1,4 +1,5 @@
 $ ./a.out fileT4A.txt fileT4B.txt
+1c1
 < CO is the best course in the world.
 ---
 > co is the best course in the world.

--- a/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-5.xcscheme
+++ b/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-5.xcscheme
@@ -53,7 +53,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "&quot;$(PROJECT_DIR)/a5-diff/test5/fileT5A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test5/fileT5B.txt&quot;"
+            argument = "-i &quot;$(PROJECT_DIR)/a5-diff/test5/fileT5A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test5/fileT5B.txt&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-6.xcscheme
+++ b/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-6.xcscheme
@@ -53,7 +53,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "&quot;$(PROJECT_DIR)/a5-diff/test6/fileT6A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test6/fileT6B.txt&quot;"
+            argument = "-B &quot;$(PROJECT_DIR)/a5-diff/test6/fileT6A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test6/fileT6B.txt&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-7.xcscheme
+++ b/co-framework.xcodeproj/xcshareddata/xcschemes/assignment-5-test-7.xcscheme
@@ -53,7 +53,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "&quot;$(PROJECT_DIR)/a5-diff/test7/fileT7A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test7/fileT7B.txt&quot;"
+            argument = "-i -B &quot;$(PROJECT_DIR)/a5-diff/test7/fileT7A.txt&quot; &quot;$(PROJECT_DIR)/a5-diff/test7/fileT7B.txt&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
This PR adds the proper `-i` and `-B` flags for the 5a run-schemes (tests 5, 6, 7), adds a missing line to `expectedResult4` for 5a and an empty line to `fileT1A` for 5a 