### PR TITLE
Fixes for 5A frame file

### DIFF
--- a/a5-diff/a5-diff-frame.S
+++ b/a5-diff/a5-diff-frame.S
@@ -11,7 +11,7 @@
     fprintf: jmp _fprintf
     fscanf: jmp _fscanf
     printf: jmp _printf
-    strcasecmp: jmp _strncasecmp
+    strcasecmp: jmp _strcasecmp
     strcmp: jmp _strcmp
     strcpy: jmp _strcpy
     strlen: jmp _strlen
@@ -31,6 +31,7 @@ changestring:
 		    .ascii "---\n"
 		    .asciz "> %s\n"
 
+.global diff
 
 # ************************************************************************
 # * Subroutine: diff


### PR DESCRIPTION
This PR fixes the redirect of `strcasecmp` to `_strcasecmp` for mac and adds the global declaration for the diff function to work with the CodeGrade setup. 